### PR TITLE
bet list winning status

### DIFF
--- a/app/bet_lists/at_term_bet_lists.py
+++ b/app/bet_lists/at_term_bet_lists.py
@@ -42,7 +42,7 @@ with win_bl_tab:
             st.dataframe(
                 df_bet_list,
                 column_config={
-                    "match_date":st.column_config.DateColumn('date',format="YYYY-MM-DD HH:mm"),
+                    "match_date":st.column_config.DateColumn('date',format="DD-MM-YYYY HH:mm"),
                     "odd_value":st.column_config.NumberColumn('odd value', format="%.2f"),
                 }
             )

--- a/app/bet_lists/at_term_bet_lists.py
+++ b/app/bet_lists/at_term_bet_lists.py
@@ -1,0 +1,81 @@
+import streamlit as st
+from data import (
+    get_bet_lists_wide_df,
+    get_winning_and_losing_bet_lists,
+    get_winning_and_losing_bet_lists_count
+)
+
+def highlight_losing_odds(row):
+    if row.is_winning == False:
+        return ['font-weight: bold; color: red' for r in row]
+    else:
+        return ['' for r in row]
+
+
+st.header('At-term bet lists')
+
+df_at_term_bet_lists = get_bet_lists_wide_df()
+dc_win_lost_bet_lists = get_winning_and_losing_bet_lists(df_at_term_bet_lists)
+dc_win_lose_bet_lists_count = get_winning_and_losing_bet_lists_count(dc_win_lost_bet_lists)
+win_col, lose_col = st.columns(2)
+win_col.metric(label=r"# Winning bet lists", value=dc_win_lose_bet_lists_count["winning"])
+lose_col.metric(label=r"# Losing bet lists", value=dc_win_lose_bet_lists_count["losing"])
+win_bl_tab, lose_bl_tab = st.tabs(["🟩 &nbsp; &nbsp; Winning Bet Lists", "🟥 &nbsp; &nbsp; Losing Bet Lists"])
+with win_bl_tab:
+    winning_bet_lists = [
+        bl_name 
+        for bl_name, is_winning in dc_win_lost_bet_lists.items()
+        if is_winning == True
+    ]
+    for bet_list_name in winning_bet_lists:
+        df_bet_list = (
+            df_at_term_bet_lists
+            .query('bet_list_name == @bet_list_name')
+            .drop(columns=["bet_list_name", "is_winning"])
+        )
+        total_odds = f'{df_bet_list.odd_value.product():.2f}'
+        match_count = df_bet_list.description.count()
+        with st.expander(
+            f"**{bet_list_name}**  \n"
+            f"∑ Odds: :green[{total_odds}] &nbsp; &nbsp; &nbsp; \# Matches: :green[{match_count}]"
+        ):
+            st.dataframe(
+                df_bet_list,
+                column_config={
+                    "match_date":st.column_config.DateColumn('date',format="YYYY-MM-DD HH:mm"),
+                    "odd_value":st.column_config.NumberColumn('odd value', format="%.2f"),
+                }
+            )
+with lose_bl_tab:
+    losing_bet_lists = [
+        bl_name 
+        for bl_name, is_winning in dc_win_lost_bet_lists.items()
+        if is_winning == False
+    ]
+    for bet_list_name in losing_bet_lists:
+        df_bet_list = (
+            df_at_term_bet_lists
+            .query('bet_list_name == @bet_list_name')
+            .drop(columns=["bet_list_name"])
+        )
+        total_odds = f'{df_bet_list.odd_value.product():.2f}'
+        match_count = df_bet_list.description.count()
+        losing_match_count = df_bet_list.query('is_winning == False').description.count()
+        with st.expander(
+            f"**{bet_list_name}**  \n"
+            f"∑ Odds: :red[{total_odds}] &nbsp; &nbsp; &nbsp; \# Losing Matches: :red[{losing_match_count}/{match_count}]"
+        ):
+            
+            styled_df_bet_list = (
+                df_bet_list
+                .style.apply(highlight_losing_odds, axis=1)
+                .format(precision=2)
+            )
+            st.dataframe(
+                styled_df_bet_list,
+                column_config={
+                    "match_date":st.column_config.DateColumn('date',format="YYYY-MM-DD HH:mm"),
+                    "odd_value":st.column_config.NumberColumn('odd value', format="%.2f"),
+                    "is_winning":st.column_config.CheckboxColumn('is winning', width="small")
+                }
+            )

--- a/app/bet_lists/search_bet_lists.py
+++ b/app/bet_lists/search_bet_lists.py
@@ -1,6 +1,6 @@
 import streamlit as st
 from data import (
-    get_saved_bet_lists, 
+    get_on_going_bet_lists, 
     get_bet_list_df,
     drop_bet_list
 )
@@ -16,11 +16,11 @@ def drop_bet_list_dialog(bet_list_name):
     if no_col.button('No'):
         st.rerun()
 
-df_saved_bet_lists = get_saved_bet_lists()
+df_on_going_bet_lists = get_on_going_bet_lists()
 
 selected_bet_list_name = st.selectbox(
     label="Select a bet list",
-    options=df_saved_bet_lists.bet_list_name.to_list(),
+    options=df_on_going_bet_lists.bet_list_name.to_list(),
     index=None
 )
 if selected_bet_list_name:

--- a/app/bet_lists/utils.py
+++ b/app/bet_lists/utils.py
@@ -3,7 +3,6 @@ from functools import reduce
 import streamlit as st
 import datetime as dt
 import pandas as pd
-from data import get_odds_table, upsert_bet_list
 from app_session import (
     SessionKey, 
     update_bet_list_odd_in_session,
@@ -55,32 +54,11 @@ def create_or_update_bet_list():
         action = SessionKey.CREATE_UPDATE_BET_LIST_ACTION.get()
         bet_list_to_cu = SessionKey.UPDATE_BET_LIST_NAME.get()
     else:
-        action = st.selectbox(
-            label="Do you want to create or update the bet list",
-            options=[
-                action.value for action in CREATE_UPDATE_BET_LIST_ACTION
-            ],
-            format_func=lambda x_: x_.title(),
-        )
-        if action:
-            if action.lower() == CREATE_UPDATE_BET_LIST_ACTION.UPDATE:
-                existing_bet_lists_in_db = get_bet_list_names_in_db()
-                # bet_lists_in_session = list(SessionKey.BET_LISTS.get().values())
-                # bet_lists_options = existing_bet_lists_in_db + bet_lists_in_session
-                bet_list_options = get_bet_list_names_in_db()
-                bet_list_to_cu = st.selectbox(
-                    label='Select the bet list you want to update',
-                    options=bet_list_options,
-                    index=None
-                )
-                SessionKey.UPDATE_BET_LIST_NAME.update(bet_list_to_cu)
-            elif action.lower() == CREATE_UPDATE_BET_LIST_ACTION.CREATE:
-                bet_list_to_cu = st.text_input("Name of the bet list")
-                if not bet_list_to_cu:
-                    st.warning('First create a name for your bet list')
-        
-    
-            SessionKey.CREATE_UPDATE_BET_LIST_ACTION.update(action)
+        action = CREATE_UPDATE_BET_LIST_ACTION.CREATE
+        bet_list_to_cu = st.text_input("Name of the bet list")
+        if not bet_list_to_cu:
+            st.warning('First create a name for your bet list')
+        SessionKey.CREATE_UPDATE_BET_LIST_ACTION.update(action)
     return bet_list_to_cu
 
 def display_df_program(ls_selected=None):
@@ -202,7 +180,7 @@ def display_new_bet_list_form(bet_list_name, df_program_matches, df_previous_bet
             
 
 
-    form_submited = st.button('Add bet list')
+    form_submited = st.button('Save bet list')
 
     if form_submited:
         bet_list_odds = [
@@ -227,6 +205,7 @@ def display_previous_odd(match, df_match_odds, df_previous_bet_list_odds):
     return (
         df_match_odds
         .style.apply(color_previous_odd, axis=0, subset=[highlighted_col])
+        .format(precision=2)
     )
 
 

--- a/app/data.py
+++ b/app/data.py
@@ -8,23 +8,29 @@ import sqlite3
 import requests as rq
 import pandas as pd
 import sqlalchemy
-from sqlalchemy import Column, ForeignKey, String, Table, insert, select, text, update
+from sqlalchemy import create_engine, MetaData, event
+from sqlalchemy import ForeignKey, select, text, JSON
 from sqlalchemy.orm  import (
-    DeclarativeBase,
+    declarative_base,
     Mapped,
     Session,
+    sessionmaker,
     mapped_column,
     relationship,
-    selectinload,
 )
 
 from app_session import SessionKey
 
 #region DB engines
 
+IN_MEMORY_SQLALCHEMY_DB_ENGINE = create_engine('sqlite://')
+
 def get_sqlite_local_db_engine():
     # return sqlite3.connect("file::memory:?cache=shared", uri=True)
     return sqlite3.connect("local.database.db")
+
+def get_sqlalchemy_local_db_engine():
+    return sqlalchemy.create_engine("sqlite:///local.database.db")
 
 def get_sqlite_sporacle_db_engine():
     return sqlite3.connect("database.db")
@@ -32,38 +38,35 @@ def get_sqlite_sporacle_db_engine():
 def get_sqlalchemy_sporacle_engine():
     return sqlalchemy.create_engine("sqlite:///database.db")
 
+def get_sqlalchemy_cross_database_engine():
+    engine = create_engine('sqlite://')
+    with engine.connect() as connection:
+        _ = connection.execute(text("attach 'database.db' as sporacle_db;"))
+        _ = connection.execute(text("attach 'local.database.db' as app_db;"))
+    Session = sessionmaker(bind=engine)
+    session = Session()
+    return session
+
+@event.listens_for(IN_MEMORY_SQLALCHEMY_DB_ENGINE, "connect", insert=True)
+def set_current_schema(dbapi_connection, connection_record):
+    cursor_obj = dbapi_connection.cursor()
+    cursor_obj.execute("attach 'database.db' as sporacle_db;")
+    cursor_obj.execute("attach 'local.database.db' as app_db;")
+    cursor_obj.close()
+
+
 #endregion
 
 #region ORM
-class Base(DeclarativeBase):
-    pass
 
-bet_lists__bet_list_odds_association = Table(
-    'bet_lists__bet_list_odds',
-    Base.metadata,
-    Column('bet_list_name', String, ForeignKey('bet_lists.bet_list_name')),
-    Column('odd_key', String, ForeignKey('bet_list_odds.key'))
-)
+Base = declarative_base()
 
-class BetListOdd(Base):
-
-    __tablename__ = "bet_list_odds"
-    key: Mapped[str] = mapped_column(primary_key=True)
-    odd_match_code: Mapped[int]
-    odd_name: Mapped[str]
-    odd_value: Mapped[float]
-    odd_threshold: Mapped[Optional[float]]
-
-    bet_lists: Mapped["BetList"] = relationship(
-        secondary=bet_lists__bet_list_odds_association, 
-        back_populates='odds',
-        viewonly=True
-    )
-    # match: Mapped["BetListMatch"] = relationship(back_populates="odds")
 
 class BetList(Base):
 
     __tablename__ = "bet_lists"
+    __table_args__ = {"schema": "app_db"}
+
 
     bet_list_name: Mapped[str] = mapped_column(primary_key=True)
     creation_date: Mapped[dt.datetime] = mapped_column(default=dt.datetime.now())
@@ -71,46 +74,95 @@ class BetList(Base):
         default=dt.datetime.now(),
         onupdate=dt.datetime.now()
     )
-    odds: Mapped[list["BetListOdd"]] = relationship(
-        secondary=bet_lists__bet_list_odds_association, 
-        back_populates='bet_lists'
+    odds: Mapped[JSON] = mapped_column(type_=JSON, nullable=False)
+    earliest_match_date: Mapped[Optional[dt.datetime]]
+    last_match_date: Mapped[Optional[dt.datetime]]
+
+
+class Odd(Base):
+    __tablename__ = "odds"
+    __table_args__ = {"schema": "sporacle_db"}
+
+    key: Mapped[str] = mapped_column(primary_key=True)
+    odd_name: Mapped[str]
+    odd_value: Mapped[float]
+    odd_threshold: Mapped[Optional[float]] = mapped_column()
+    is_winning: Mapped[Optional[bool]]
+
+    odd_match_code: Mapped[int] = mapped_column(
+        ForeignKey("sporacle_db.matches.odd_match_code")
+    )
+
+    match: Mapped["Match"] = relationship(back_populates="odds")
+
+
+class Match(Base):
+    __tablename__ = "matches"
+    __table_args__ = {"schema": "sporacle_db"}
+
+    odd_match_code: Mapped[int] = mapped_column(primary_key=True)
+    competition_code: Mapped[int] = mapped_column(
+        ForeignKey("sporacle_db.competitions.competition_code")
+    )
+    match_date: Mapped[dt.datetime]
+    description: Mapped[str]
+    sport_radar_match_code: Mapped[Optional[int]]
+    home_team: Mapped[str]
+    away_team: Mapped[str]
+    half_time_home_goals: Mapped[Optional[int]]
+    half_time_away_goals: Mapped[Optional[int]]
+    full_time_home_goals: Mapped[Optional[int]]
+    full_time_away_goals: Mapped[Optional[int]]
+
+    odds: Mapped[list["Odd"]] = relationship(
+        back_populates="match", cascade="all, delete-orphan"
+    )
+
+    competition: Mapped["Competition"] = relationship(back_populates="matches")
+
+
+class Competition(Base):
+    __tablename__ = "competitions"
+    __table_args__ = {"schema": "sporacle_db"}
+
+    competition_code: Mapped[int] = mapped_column(primary_key=True)
+    name: Mapped[str]
+    is_top_competition: Mapped[bool]
+
+    matches: Mapped[list["Match"]] = relationship(
+        back_populates="competition", cascade="all, delete-orphan"
     )
 
 
-def get_sqlalchemy_local_db_engine():
-    return sqlalchemy.create_engine("sqlite:///local.database.db")
+def create_all_tables():
+    Base.metadata.create_all(IN_MEMORY_SQLALCHEMY_DB_ENGINE)
 
-def create_all_tables_in_db():
-    engine = get_sqlalchemy_local_db_engine()
-    Base.metadata.create_all(engine)
 
 #endregion
 
 #region DB management
 def init_database():
-    create_all_tables_in_db()
-    copy_odds_from_db_to_local_db()
+    create_all_tables()
 
 def create_or_replace_local_db():
     local_db_path = pathlib.Path('local.database.db')
     if local_db_path.exists():
         os.remove(local_db_path)
     _ = get_sqlite_local_db_engine()
-    init_database()
 
 
 def attach_sporacle_db_to_local_db():
-    engine = get_sqlite_local_db_engine()
+    engine = get_sqlalchemy_local_db_engine()
     with engine.connect() as con:
         con.execute(text("ATTACH DATABASE 'database.db' AS 'odds_db';"))
         con.commit()
-        con.execute()
 
 def initial_app_setup(sporacle_bytes_data):
     with open("database.db", 'wb') as f:
         f.write(sporacle_bytes_data)
     _ = get_sqlite_sporacle_db_engine()
     create_or_replace_local_db()
+    create_all_tables()
     SessionKey.SPORACLE_DB_DOWNLOADED.update(True)
     SessionKey.LOCAL_DB_INITIALIZED.update(True)
 
@@ -118,23 +170,6 @@ def add_uploaded_db_file(uploaded_db_file):
     with open("local.database.db", 'wb') as f:
         f.write(uploaded_db_file.getvalue())
 
-def copy_odds_from_db_to_local_db():
-    local_engine = get_sqlalchemy_local_db_engine()
-    with local_engine.connect() as con:
-
-        con.execute(text("ATTACH DATABASE 'database.db' AS 'odds_db';"))
-        con.commit()
-        con.execute(
-            text(
-                """
-                INSERT OR REPLACE INTO bet_list_odds(
-                key, odd_match_code, odd_name, odd_value, odd_threshold
-                ) SELECT key, odd_match_code, odd_name, odd_value, odd_threshold
-                FROM odds_db.odds;
-                """
-            )
-        )
-        con.commit()
 #endregion
 
 #region Query utils
@@ -188,9 +223,6 @@ def get_competitions():
 def get_saved_bet_lists():
     return get_localdb_table('bet_lists')
 
-def get_odds_from_localdb():
-    return get_localdb_table('bet_list_odds')
-
 def get_program():
     final_cols = [
         'match_date', 'competition_name', 'description', 
@@ -229,7 +261,7 @@ def get_program():
     )
 
 def get_bet_list_names_in_db():
-    engine = get_sqlalchemy_local_db_engine()
+    engine = IN_MEMORY_SQLALCHEMY_DB_ENGINE
     if sqlalchemy.inspect(engine).has_table(BetList.__tablename__):
         with Session(engine) as session:
             select_statement = select(BetList.bet_list_name)
@@ -239,7 +271,7 @@ def get_bet_list_names_in_db():
         return []
     
 def get_matches_for_odds(match_codes):
-    engine = get_sqlalchemy_sporacle_engine()
+    engine = IN_MEMORY_SQLALCHEMY_DB_ENGINE
     match_codes_as_str = ', '.join(
         [f"'{code}'" for code in match_codes]
     )
@@ -249,8 +281,8 @@ def get_matches_for_odds(match_codes):
         matches.description,
         matches.match_date as match_datetime,
         competitions.name as competition
-    from matches
-    left join competitions
+    from sporacle_db.matches as matches
+    left join sporacle_db.competitions as competitions
         on matches.competition_code = competitions.competition_code
     where matches.odd_match_code in ({match_codes})
     """.format(
@@ -264,16 +296,20 @@ def get_matches_for_odds(match_codes):
 
 
 def get_odds_for_bet_list(bet_list_name):
-    engine = get_sqlalchemy_local_db_engine()
+    engine = IN_MEMORY_SQLALCHEMY_DB_ENGINE
     with Session(engine) as session:
-        with session.begin():
-            bet_list_odds_select_statement = (
-                select(BetList)
-                .where(BetList.bet_list_name==bet_list_name)
-                .options(selectinload(BetList.odds))
-            )
-            bet_list_obj = session.execute(bet_list_odds_select_statement).scalars().one()
-            ls_odds = [odd.__dict__ for odd in bet_list_obj.odds]
+        bet_list_statement = (
+            select(BetList)
+            .where(BetList.bet_list_name==bet_list_name)
+        )
+        bet_list = session.scalars(bet_list_statement).one()
+        ls_odd_keys = [o for o in bet_list.odds]
+        odds_statement = (
+            select(Odd)
+            .where(Odd.key.in_(ls_odd_keys))
+        )
+        odds = session.scalars(odds_statement).all()
+        ls_odds = [odd.__dict__ for odd in odds]
     df = pd.DataFrame(ls_odds)
     return df
 
@@ -301,20 +337,14 @@ def get_bet_list_df(bet_list_name):
     )
 
 def get_selected_matches_for_bet_list(bet_list_name):
-    engine = get_sqlalchemy_local_db_engine()
-    select_statement = (
-        select(BetListOdd.odd_match_code)
-        .where(BetListOdd.bet_lists.has(bet_list_name=bet_list_name))
-    )
-    with Session(engine) as session:
-        results = session.execute(select_statement).all()
-        return [r[0] for r in results]
+    df_odds = get_odds_for_bet_list(bet_list_name)
+    return df_odds.odd_match_code.to_list()
 
 def get_existing_bet_list_summary(odd_keys):    
     odd_keys_as_str = ', '.join(
         [f"'{key}'" for key in odd_keys]
     )
-    engine = get_sqlalchemy_sporacle_engine()
+    engine = IN_MEMORY_SQLALCHEMY_DB_ENGINE
     query = """
     select
         matches.description,
@@ -325,9 +355,9 @@ def get_existing_bet_list_summary(odd_keys):
         odds.odd_value as odd_value,
         odds.odd_threshold as odd_threshold,
         matches.odd_match_code
-    from odds
-    left join matches using (odd_match_code)
-    left join competitions using (competition_code)
+    from sporacle_db.odds as odds
+    left join sporacle_db.matches as matches using (odd_match_code)
+    left join sporacle_db.competitions as competitions using (competition_code)
     where odds.key in ({odd_keys})
     """.format(odd_keys=odd_keys_as_str)
     df_summary = get_table_from_query(
@@ -335,8 +365,6 @@ def get_existing_bet_list_summary(odd_keys):
         query=query
     )
     return df_summary.to_dict(orient="records")
-    # on odds.odd_match_code = matches.odd_match_code
-    # on matches.competition_code = competitions.competition_code
 #endregion
 
 #region Data Cleaning
@@ -365,8 +393,9 @@ def clean_odds(df):
 
 #region CUD        
 def upsert_bet_list(bet_list_name, bet_list_odds):
-    engine = get_sqlalchemy_local_db_engine()
+    engine = IN_MEMORY_SQLALCHEMY_DB_ENGINE
     odd_keys = [odd_dict["key"] for odd_dict in bet_list_odds]
+    odd_dates = [odd_dict["match_datetime"] for odd_dict in bet_list_odds]
     with Session(engine) as session: 
         with session.begin():
             # Fetch existing bet list object if exists
@@ -378,23 +407,23 @@ def upsert_bet_list(bet_list_name, bet_list_odds):
             bet_list_exists = session.query(
                 existing_bet_list_statement.exists()
             ).scalar()
-            # Fetch corresponding odds objects
-            odds_select_statement = (
-                select(BetListOdd)
-                .where(BetListOdd.key.in_(odd_keys))
-            )
-            odds_results = session.scalars(odds_select_statement).all()            
             if bet_list_exists:
                 existing_bet_list = session.scalar(existing_bet_list_statement)
-                existing_bet_list.odds.clear()
-                existing_bet_list.odds.extend(odds_results)
+                existing_bet_list.odds = odd_keys
+                existing_bet_list.earliest_match_date = min(odd_dates)
+                existing_bet_list.last_match_date = max(odd_dates)
                 session.add(existing_bet_list)
             else:
-                bet_list_obj = BetList(bet_list_name=bet_list_name)
-                bet_list_obj.odds.extend(odds_results)
+                bet_list_obj = BetList(
+                    bet_list_name=bet_list_name, 
+                    odds=odd_keys,
+                    earliest_match_date=min(odd_dates),
+                    last_match_date=max(odd_dates)
+                )
                 session.add(bet_list_obj)
+
 def drop_bet_list(bet_list_name):
-    engine = get_sqlalchemy_local_db_engine()
+    engine = IN_MEMORY_SQLALCHEMY_DB_ENGINE
     with Session(engine) as session: 
         with session.begin():
             # Fetch existing bet list object if exists
@@ -406,4 +435,85 @@ def drop_bet_list(bet_list_name):
             bet_list = session.scalar(existing_bet_list_statement)
             session.delete(bet_list)
 
+def get_bet_lists_wide_df():
+    engine = IN_MEMORY_SQLALCHEMY_DB_ENGINE
+    query = """
+    with extracted_odd_keys as (
+        SELECT
+            bet_lists.bet_list_name, 
+            odd_keys.value as key
+        FROM app_db.bet_lists as bet_lists
+        JOIN json_each(bet_lists.odds) as odd_keys
+    ),
+
+    bet_list_summary as (
+        SELECT
+            extracted_odd_keys.bet_list_name as bet_list_name,
+            matches.description as description,
+            matches.match_date as match_date,
+            competitions.name as competition,
+            (
+                matches.half_time_home_goals || '-' || matches.half_time_away_goals
+            ) as half_time_score,
+            (
+                matches.full_time_home_goals || '-' || matches.full_time_away_goals
+            ) as full_time_score,
+            odds.odd_name as odd_name,
+            odds.odd_value as odd_value,
+            odds.is_winning as is_winning,
+            extracted_odd_keys.key as key,
+            odds.odd_match_code as odd_match_code,
+            matches.competition_code as competition_code
+        FROM extracted_odd_keys
+        LEFT JOIN sporacle_db.odds as odds USING (key)
+        LEFT JOIN sporacle_db.matches as matches USING (odd_match_code)
+        LEFT JOIN sporacle_db.competitions as competitions USING (competition_code)
+    )
+
+    SELECT
+        bet_list_name,
+        description,
+        match_date,
+        competition,
+        half_time_score,
+        full_time_score,
+        odd_name,
+        odd_value,
+        is_winning
+    FROM bet_list_summary
+    """
+    df_summary = get_table_from_query(
+        engine=engine, 
+        query=query
+    )
+    return df_summary
+
+def get_winning_and_losing_bet_lists(df_summary: pd.DataFrame) -> dict[str, bool]:
+    df_win_lose_bet_lists = (
+        df_summary
+        .groupby('bet_list_name')
+        [['is_winning']]
+        .all()
+        .reset_index()
+    )
+    dc_win_lost_bet_lists = {
+        dc_["bet_list_name"]:dc_["is_winning"]
+        for dc_ in df_win_lose_bet_lists.to_dict(orient="records")
+    }
+    return dc_win_lost_bet_lists
+
+def get_winning_and_losing_bet_lists_count(
+    dc_win_lost_bet_lists: dict[str, bool]
+) -> dict[str, int]:
+    win_bet_lists_count = sum(
+        [1 for x,y in dc_win_lost_bet_lists.items() if y == True ]
+    )
+    lose_bet_list_count = sum(
+        [1 for x,y in dc_win_lost_bet_lists.items() if y == False ]
+    )
+    return {
+        "winning":win_bet_lists_count, "losing":lose_bet_list_count
+    }
+
 #endregion
+

--- a/app/home.py
+++ b/app/home.py
@@ -1,6 +1,7 @@
 from app_session import SessionKey, setup_bet_lists_in_session
 import streamlit as st
 import data
+from data import IN_MEMORY_SQLALCHEMY_DB_ENGINE
 import pyodide
 
 import requests as rq
@@ -39,12 +40,14 @@ def display_query_form():
     with st.expander('Query databases'):
         selected_db = st.selectbox(
             label='What database do you want to query ?', 
-            options=["Sporacle", "Local DB"]
+            options=["Sporacle", "Local DB", "Cross-Database"]
         )
         if selected_db == "Sporacle":
             engine = data.get_sqlalchemy_sporacle_engine()
         elif selected_db == "Local DB":
             engine = data.get_sqlalchemy_local_db_engine()
+        elif selected_db == "Cross-Database":
+            engine = IN_MEMORY_SQLALCHEMY_DB_ENGINE
         else:
             raise NotImplementedError("The database should be either Sporacle or Local DB")
         query = st.text_area(f"Query to {selected_db}")

--- a/app/index.html
+++ b/app/index.html
@@ -7,7 +7,7 @@
       name="viewport"
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
-    <title>stlite app</title>
+    <title>Sporacle App</title>
     <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/@stlite/mountable@0.68.0/build/stlite.css"
@@ -34,6 +34,9 @@
                     "data.py": {
                         url: "./data.py"
                     },
+                    "bet_lists/at_term_bet_lists.py": {
+                        url: "./bet_lists/at_term_bet_lists.py"
+                    },
                     "bet_lists/create_update_bet_list.py": {
                         url: "./bet_lists/create_update_bet_list.py"
                     },
@@ -43,7 +46,7 @@
                     "bet_lists/utils.py": {
                         url: "./bet_lists/utils.py",
                     },
-                }
+                },
             }
         );
     </script>

--- a/app/main.py
+++ b/app/main.py
@@ -11,7 +11,7 @@ st.title('Sporacle App')
 
 home_page = st.Page("home.py", title="Home", icon=":material/home:")
 at_term_bet_lists = st.Page("bet_lists/at_term_bet_lists.py", title="At-term bet lists", icon=":material/fact_check:")
-search_bet_lists = st.Page("bet_lists/search_bet_lists.py", title="Search bet lists", icon=":material/search:")
+search_bet_lists = st.Page("bet_lists/search_bet_lists.py", title="Search on-going bet lists", icon=":material/search:")
 # bet_lists_page = st.Page("bet_lists/bet_lists.py", title="Bet Lists", icon=":material/table:")
 create_update_bet_list_page = st.Page("bet_lists/create_update_bet_list.py", title="Create/Update bet list", icon=":material/edit_note:")
 # new_bet_list_page = st.Page("bet_lists/new_bet_list.py", title="Create new bet list", icon=":material/format_list_numbered_rtl:")
@@ -23,9 +23,9 @@ pg = st.navigation(
         "Main":[home_page],
         "Bets":[
             # bet_lists_page, 
-            at_term_bet_lists,
             search_bet_lists,
             create_update_bet_list_page,
+            at_term_bet_lists,
             # new_bet_list_page, 
             # saved_bet_lists_page, 
             # update_bet_list_page

--- a/app/main.py
+++ b/app/main.py
@@ -10,6 +10,7 @@ import streamlit as st
 st.title('Sporacle App')
 
 home_page = st.Page("home.py", title="Home", icon=":material/home:")
+at_term_bet_lists = st.Page("bet_lists/at_term_bet_lists.py", title="At-term bet lists", icon=":material/fact_check:")
 search_bet_lists = st.Page("bet_lists/search_bet_lists.py", title="Search bet lists", icon=":material/search:")
 # bet_lists_page = st.Page("bet_lists/bet_lists.py", title="Bet Lists", icon=":material/table:")
 create_update_bet_list_page = st.Page("bet_lists/create_update_bet_list.py", title="Create/Update bet list", icon=":material/edit_note:")
@@ -22,6 +23,7 @@ pg = st.navigation(
         "Main":[home_page],
         "Bets":[
             # bet_lists_page, 
+            at_term_bet_lists,
             search_bet_lists,
             create_update_bet_list_page,
             # new_bet_list_page, 


### PR DESCRIPTION
- add at-term bet lists page
- refactor ORM to use cross-database session
- refactor create / update bet list page
- search bet lists -> search on-going bet lists
- refactor get_program to get only future matches
- refactor get_bet_lists_wide_df to get only at-term odds
- order odds in create/update bet list